### PR TITLE
Treat @ts directives as special

### DIFF
--- a/rules/src/rules/limit-multi-line-comments.ts
+++ b/rules/src/rules/limit-multi-line-comments.ts
@@ -398,7 +398,11 @@ function isSpecialComment(comment: Comment): boolean {
     comment.value.includes("tslint:disable") ||
     comment.value.includes("eslint-enable") ||
     comment.value.includes("stylelint-enable") ||
-    comment.value.includes("tslint:enable")
+    comment.value.includes("tslint:enable") ||
+    comment.value.includes("@ts-ignore") ||
+    comment.value.includes("@ts-expect-error") ||
+    comment.value.includes("@ts-check") ||
+    comment.value.includes("@ts-nocheck")
   );
 }
 

--- a/rules/src/rules/limit-single-line-comments.ts
+++ b/rules/src/rules/limit-single-line-comments.ts
@@ -260,7 +260,11 @@ function isSpecialComment(comment: Comment): boolean {
     comment.value.trim().startsWith("tslint:disable") ||
     comment.value.trim().startsWith("eslint-enable") ||
     comment.value.trim().startsWith("stylelint-enable") ||
-    comment.value.trim().startsWith("tslint:enable")
+    comment.value.trim().startsWith("tslint:enable") ||
+    comment.value.trim().startsWith("@ts-ignore") ||
+    comment.value.trim().startsWith("@ts-expect-error") ||
+    comment.value.trim().startsWith("@ts-check") ||
+    comment.value.trim().startsWith("@ts-nocheck")
   );
 }
 


### PR DESCRIPTION
Hey, thanks for a great plugin!

This PR makes the plugin treat comments like

```ts
// @ts-ignore Ignore the next line because (long reason exceeding 80 characters and making the line very long)
```

as special. These comments affect how TypeScript treats the next line and therefore must not be wrapped into multiple lines.