### PR TITLE
feat: allow the use of custom semantic comments

### DIFF
--- a/rules/src/rules/limit-multi-line-comments/root.ts
+++ b/rules/src/rules/limit-multi-line-comments/root.ts
@@ -31,7 +31,7 @@ export function limitMultiLineComments(
       !comment.loc ||
       comment.type !== "Block" ||
       !isCommentOnOwnLine(sourceCode, comment) ||
-      isSemanticComment(comment)
+      isSemanticComment(comment, options.semanticComments)
     ) {
       continue;
     }

--- a/rules/src/rules/limit-single-line-comments/root.ts
+++ b/rules/src/rules/limit-single-line-comments/root.ts
@@ -31,7 +31,7 @@ export function limitSingleLineComments(
       !currentCommentLine?.range ||
       !currentCommentLine.value ||
       !isCommentOnOwnLine(sourceCode, currentCommentLine) ||
-      isSemanticComment(currentCommentLine)
+      isSemanticComment(currentCommentLine, options.semanticComments)
     ) {
       continue;
     }

--- a/rules/src/rules/limit-single-line-comments/util.capture-relevant-comments.ts
+++ b/rules/src/rules/limit-single-line-comments/util.capture-relevant-comments.ts
@@ -31,7 +31,7 @@ export function captureRelevantCommentsIntoBlock(
       !nextComment ||
       nextComment.value.trim() === "" ||
       nextComment.loc?.start.line !== (comment.loc?.end.line ?? 0) + 1 ||
-      isSemanticComment(nextComment) ||
+      isSemanticComment(nextComment, context.semanticComments) ||
       !isCommentOnOwnLine(sourceCode, nextComment)
     ) {
       break;

--- a/rules/src/typings.options.ts
+++ b/rules/src/typings.options.ts
@@ -66,6 +66,7 @@ export type Options = {
    * @default 2
    */
   tabSize: number;
+  semanticComments?: string[];
 };
 
 export type RuleOptions = [Options];

--- a/rules/src/utils/is-semantic-comment.ts
+++ b/rules/src/utils/is-semantic-comment.ts
@@ -2,13 +2,20 @@ import { TSESTree } from "@typescript-eslint/utils";
 
 export function isSemanticComment(
   comment: TSESTree.BlockComment | TSESTree.LineComment,
+  semanticComments?: string[],
 ): boolean {
+  const includesCustomSemanticComment =
+    semanticComments?.some((semanticComment) =>
+      comment.value.includes(semanticComment),
+    ) || false;
+
   return (
     comment.value.includes("eslint-disable") ||
     comment.value.includes("stylelint-disable") ||
     comment.value.includes("tslint:disable") ||
     comment.value.includes("eslint-enable") ||
     comment.value.includes("stylelint-enable") ||
-    comment.value.includes("tslint:enable")
+    comment.value.includes("tslint:enable") ||
+    includesCustomSemanticComment
   );
 }


### PR DESCRIPTION
Hi, as requested here https://github.com/lasselupe33/eslint-plugin-comment-length/issues/16 I roughly added the functionality. Do you think it is useful and can be added? If yes, then I can think about adding comments and documentation.

Let me know if you like the term `semanticComments` for the option or if you think other terms might better clarify its purpose.