### PR TITLE
fix: rename unused parameter

### DIFF
--- a/rules/src/rules/limit-multi-line-comments/detect.overflow.ts
+++ b/rules/src/rules/limit-multi-line-comments/detect.overflow.ts
@@ -6,7 +6,7 @@ import { isLineOverflowing } from "../../utils/is-line-overflowing.js";
 import type { MultilineBlock } from "./typings.block.js";
 
 export function detectOverflowInMultilineBlocks(
-  ruleContext: RuleContext<string, unknown[]>,
+  _ruleContext: RuleContext<string, unknown[]>,
   context: Context,
   blocks: MultilineBlock[],
 ) {


### PR DESCRIPTION
Prefix the unused `ruleContext` parameter for
`detectOverflowInMultilineBlocks` with an underscore. This is to prevent this code causing Typescript errors in consuming projects which have the `noUnusedParameters` compiler option enabled.