### PR TITLE
Add homepage and bugs.url package metadata

### DIFF
--- a/rules/package.json
+++ b/rules/package.json
@@ -38,6 +38,10 @@
     "type": "git",
     "url": "https://github.com/lasselupe33/eslint-plugin-comment-length.git"
   },
+  "homepage": "https://github.com/lasselupe33/eslint-plugin-comment-length/tree/master/rules#readme",
+  "bugs": {
+    "url": "https://github.com/lasselupe33/eslint-plugin-comment-length/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "@typescript-eslint/utils": "^8.59.0"


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `eslint-plugin-comment-length`
- updates only `rules/package.json`

## Metadata added
- `homepage`: `https://github.com/lasselupe33/eslint-plugin-comment-length/tree/master/rules#readme`
- `bugs.url`: `https://github.com/lasselupe33/eslint-plugin-comment-length/issues`

## Validation
- parsed `rules/package.json` as JSON after the change
- confirmed the manifest still has `name: eslint-plugin-comment-length`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package expose the project support/discovery information once the package is next released.